### PR TITLE
Updated packages and a fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A simple command line tool to generate fonts for Mapbox GL via fontnik without g
 
 Usage: ```genfontgl OpenSans-Regular.ttf```
 
+Or if not installed globally: ```npm run genfontgl -- OpenSans-Regular.ttf```
+
 Based on:
 * [Fontmachine](https://github.com/mapbox/fontmachine)
 * [build-glyphs](https://github.com/mapbox/node-fontnik/blob/master/bin/build-glyphs)

--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@
 
 var fs = require('fs');
 var fontnik = require('fontnik');
-var queue = require('queue-async');
+var d3 = require('d3-queue');
 
     try {
         var fname = process.argv[2];
-	
+
 	var fontstack = fs.readFileSync(fname);
         console.log('Process '+fname);
-        
+
         var folder=fname.slice(0, -4).replace('-','');
     } catch (e) {
         console.error('error: could not read font '+e)
@@ -18,14 +18,14 @@ var queue = require('queue-async');
 
     if(!fs.existsSync(folder)){
        fs.mkdirSync(folder, 0766, function(err){
-         if(err){ 
+         if(err){
             console.log(err);
             response.send("ERROR! Can't make the directory! \n");
          }
-       });   
+       });
     }
 
-     var q = queue(Math.max(4, require('os').cpus()));
+     var q = d3.queue(Math.max(4, require('os').cpus().length));
      var queue = [];
      for (var i = 0; i < 65536; (i = i + 256)) {
          q.defer(writeGlyphs, {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "Create a fontstack folder from a TTF font for Mapbox GL",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "genfontgl": "node index.js"
   },
   "dependencies": {
-    "fontnik": "^0.3.2",
-    "queue-async": "^1.0.7"
+    "d3-queue": "^2.0.2",
+    "fontnik": "^0.4.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Thanks for making this! It's exactly what I needed.

I couldn't get the version of fontnik you were referencing to build (node 5.6.0 linux), but updating to the latest fontnik version fixed that. I also swapped in d3-queue as the other was depricated in favor of it. I made a npm run script for it for convenience for non-global installs.

Beyond that there was only one fix - Math.max(4, require('os').cpus()) was causing an error, as cpus() returns an array (perhaps this is new behavior). Changed it to Math.max(4, require('os').cpus().length) and it works great.
