### PR TITLE
Handle ttf not in root

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var fontnik = require('fontnik');
 var d3 = require('d3-queue');
 
     try {
-        var fname = process.argv[2];
+        var fname = path.basename(process.argv[2]);
 
 	var fontstack = fs.readFileSync(fname);
         console.log('Process '+fname);


### PR DESCRIPTION
Oops, sorry - should have caught this in the last pull request. Now it handles the ttf argument being either a file (i.e. OpenSans-Light.ttf) or a path to a file (./some/dir/OpenSans-Light.ttf). 
