### PR TITLE
make output directories more like gl style usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ var d3 = require('d3-queue');
 	var fontstack = fs.readFileSync(fname);
         console.log('Process '+fname);
 
-        var folder = path.basename(fname).slice(0, -4).replace('-','');
+	var rex = /([A-Z])([A-Z])([a-z])|([a-z])([A-Z])/g;
+        var folder = path.basename(fname).slice(0, -4).replace('-','').replace(rex, '$1$4 $2$3$5');
         if (process.argv[3]) { 
             if (fs.existsSync(process.argv[3])) {
                 folder = path.join(process.argv[3], folder);


### PR DESCRIPTION
I think this is the last one, and you may not want this for your original use case, but...

This uses regex to make the output folder "Open Sans Regular" instead of "OpenSansRegular". This makes it a lot more intuitive for using font names in style.json (it's how MapBox names its fonts).
